### PR TITLE
New Assistant breaks Chrome Web Store and another Google services

### DIFF
--- a/compiler.meta.js
+++ b/compiler.meta.js
@@ -27,7 +27,7 @@
 // @description:es	Permite fácilmente gestionar los filtros desde el navegador
 // @description:id	Menyediakan cara mudah dan nyaman untuk mengelola penyaringan langsung dari peramban
 // @description:hu	Könnyű és kényelmes módot nyújt egyenesen a böngészőből történő szűrések kezeléséhez
-// @version	4.0.2
+// @version	4.0.4
 // @downloadURL	https://cdn.adguard.com/public/Userscripts/AdguardAssistant/4.0/assistant.user.js
 // @updateURL	https://cdn.adguard.com/public/Userscripts/AdguardAssistant/4.0/assistant.meta.js
 // @include *

--- a/src/_locales/en.js
+++ b/src/_locales/en.js
@@ -1,4 +1,4 @@
-en = {
+var en = {
     "menu_filtration_status": {
         "message": "Filtering on this website"
     },

--- a/src/_locales/ru.js
+++ b/src/_locales/ru.js
@@ -1,4 +1,4 @@
-ru = {
+var ru = {
     "menu_filtration_status": {
         "message": "\u0424\u0438\u043b\u044c\u0442\u0440\u0430\u0446\u0438\u044f \u043d\u0430 \u044d\u0442\u043e\u043c \u0441\u0430\u0439\u0442\u0435"
     },


### PR DESCRIPTION
Issue #26 fix.

Because in assistant localization files:
src/_locales/en.js
src/_locales/ru.js
`var` keyword is not used we override `en` function in the global scope.