### PR TITLE
issue: AdguardForWindows/issues/1738 (improve settings validation)

### DIFF
--- a/src/settings.js
+++ b/src/settings.js
@@ -116,7 +116,7 @@ var Settings = function (log, gmApi) { // jshint ignore:line
                 continue;
             }
             var property = DefaultConfig[prop];
-            if (typeof property !== typeof settings[prop]) {
+            if (property && typeof property !== typeof settings[prop]) {
                 throw 'Invalid settings object';
             }
         }


### PR DESCRIPTION
I suggest these changes as a fix for the issue: https://github.com/AdguardTeam/AdguardForWindows/issues/1738 
For the current moment, we can use this cheap solution, without adding schema version in the settings JSON.